### PR TITLE
Reordering files to prevent build error

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -9,8 +9,10 @@
 @import "src/scss/variables";
 @import "src/scss/nav-base";
 
+@import "src/scss/theme-horizontal";
+@import "src/scss/theme-vertical";
+
 @import "src/scss/deprecated/theme-horizontal";
 @import "src/scss/deprecated/theme-vertical";
 
-@import "src/scss/theme-horizontal";
-@import "src/scss/theme-vertical";
+


### PR DESCRIPTION
Sorry, this was an embarassing error..

The deprecated code uses the mixins which are @imported **after** .  This cases errors on build.
