### PR TITLE
Added cloning ability when creating sub-nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ If there's a chance that all nav items will be hidden and added to the More list
 <li data-more class="o-hierarchical-nav__parent"><a><span class="nav__more--if-some">More</span><span class="nav__more--if-all">Menu</span></a></li>
 ```
 
+If there is a structure required for the styling of nav components (i.e. other elements are required for icon display) or elements that are not links but should reduce to a sub-level when screen space does not allow then you can add a 'data-o-hierarchical-nav--is-cloneable' attribute and the element will be deeply cloned rather than a new anchor tag with the text content copied.
+
+```html
+<li data-o-hierarchical-nav--is-cloneable><a><div>An item to clone</div><img src="" alt="icon"></a></li>
+
 ## Vertical hierarchical nav
 
 To make a nav work in a vertical layout, add `data-o-hierarchical-nav-orientiation="vertical"` to the `<nav>`.
@@ -111,7 +116,7 @@ To make a nav work in a vertical layout, add `data-o-hierarchical-nav-orientiati
 
 Add a `<i></i>` to display an arrow icon at the end of an `<a>` element:
 
-```html 
+```html
 <li class="o-hierarchical-nav__parent"><a>Item 3.2 (parent) <i></i></a>
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ If there is a structure required for the styling of nav components (i.e. other e
 
 ```html
 <li data-o-hierarchical-nav--is-cloneable><a><div>An item to clone</div><img src="" alt="icon"></a></li>
+```
 
 ## Vertical hierarchical nav
 

--- a/demos/src/config.json
+++ b/demos/src/config.json
@@ -18,6 +18,10 @@
             "name": "nav",
             "template": "demos/src/nav.mustache",
             "js": "demos/src/nav.js"
+        },
+        {
+            "name": "sub-component",
+            "template": "demos/src/sub-component.mustache"
         }
     ]
 }

--- a/demos/src/sub-component.mustache
+++ b/demos/src/sub-component.mustache
@@ -1,0 +1,13 @@
+<h1 class="demo__title">Component sub-level nav</h1>
+
+<nav class="ft-search__nav o-header__primary__right o-header__nav--tools-theme o-hierarchical-nav" data-o-component="o-hierarchical-nav">
+    <ul data-o-hierarchical-nav-level="1">
+        <li class="ft-search__nav__items" data-o-hierarchical-nav--is-cloneable>
+            <form method="get" action="/search/" id="site-wide-search">
+                <input class="search-query" type="search" name="SearchText" id="site-wide-search-field" placeholder="Search by keyword...">
+                <input name="SearchButton" type="submit" style="display:none;">
+            </form>
+        </li>
+        <li data-more class="o-hierarchical-nav__parent" aria-hidden="true"><a><span class="o-hierarchical-nav__more--if-some">More</span><span class="o-hierarchical-nav__more--if-all">Menu</span> <i></i></a></li>
+    </ul>
+</nav>

--- a/demos/sub-component.html
+++ b/demos/sub-component.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html class="o-hoverable-on o-hoverable-on">
+<head>
+	<meta charset="utf-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+	<title>o-hierarchical-nav: sub-component demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=classlist,createevent,datauri,cssgradients,mediaqueries,csstransitions,default"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-hierarchical-nav:/demos/src/scss/demo.scss,o-fonts@^1.4.0" />
+</head>
+<body>
+<h1 class="demo__title">Component sub-level nav</h1>
+
+<nav class="ft-search__nav o-header__primary__right o-header__nav--tools-theme o-hierarchical-nav" data-o-component="o-hierarchical-nav">
+    <ul data-o-hierarchical-nav-level="1">
+        <li class="ft-search__nav__items" data-o-hierarchical-nav--is-cloneable>
+            <form method="get" action="/search/" id="site-wide-search">
+                <input class="search-query" type="search" name="SearchText" id="site-wide-search-field" placeholder="Search by keyword...">
+                <input name="SearchButton" type="submit" style="display:none;">
+            </form>
+        </li>
+        <li data-more class="o-hierarchical-nav__parent" aria-hidden="true"><a><span class="o-hierarchical-nav__more--if-some">More</span><span class="o-hierarchical-nav__more--if-all">Menu</span> <i></i></a></li>
+    </ul>
+</nav>
+
+<script src="/bundles/js?modules=o-hierarchical-nav:/demos/src/responsive-nav.js,o-fonts@^1.4.0"></script>
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+</body>
+</html>

--- a/origami.json
+++ b/origami.json
@@ -34,6 +34,11 @@
             "path": "/demos/mega-dropdown.html",
             "expanded": false,
             "description": ""
+        },
+        {
+            "path": "/demos/sub-component.html",
+            "expanded": false,
+            "description": ""
         }
     ]
 }

--- a/src/js/ResponsiveNav.js
+++ b/src/js/ResponsiveNav.js
@@ -1,4 +1,4 @@
-/*global require,module*/
+/*global require,module,document,HTMLElement*/
 'use strict';
 
 var SquishyList = require('o-squishy-list');
@@ -60,7 +60,7 @@ function ResponsiveNav(rootEl) {
 		// remove the attributes that are only applicable to higher level
 		cloneEl.removeAttribute('data-priority');
 		cloneEl.removeAttribute('aria-hidden');
-		cloneEl.removeAttribute('data-is-cloneable');
+		cloneEl.removeAttribute('data-o-hierarchical-nav--is-cloneable');
 		moreListEl.appendChild(cloneEl);
 	}
 
@@ -72,7 +72,7 @@ function ResponsiveNav(rootEl) {
 			var aEl = hiddenEls[c].querySelector('a');
 			var ulEl = hiddenEls[c].querySelector('ul');
 
-			if (hiddenEls[c].hasAttribute('data-is-cloneable')) {
+			if (hiddenEls[c].hasAttribute('data-o-hierarchical-nav--is-cloneable')) {
 				cloneItemToMoreList(hiddenEls[c]);
 			} else {
 				var aText = (typeof aEl.textContent !== 'undefined') ? aEl.textContent : aEl.innerText;

--- a/src/js/ResponsiveNav.js
+++ b/src/js/ResponsiveNav.js
@@ -55,6 +55,15 @@ function ResponsiveNav(rootEl) {
 		moreListEl.appendChild(itemEl);
 	}
 
+	function cloneItemToMoreList(el) {
+		var cloneEl = el.cloneNode(true);
+		// remove the attributes that are only applicable to higher level
+		cloneEl.removeAttribute('data-priority');
+		cloneEl.removeAttribute('aria-hidden');
+		cloneEl.removeAttribute('data-is-cloneable');
+		moreListEl.appendChild(cloneEl);
+	}
+
 	// For every hidden item, add it to the more list
 	function populateMoreList(hiddenEls) {
 		emptyMoreList();
@@ -63,8 +72,12 @@ function ResponsiveNav(rootEl) {
 			var aEl = hiddenEls[c].querySelector('a');
 			var ulEl = hiddenEls[c].querySelector('ul');
 
-			var aText = (typeof aEl.textContent !== 'undefined') ? aEl.textContent : aEl.innerText;
-			addItemToMoreList(aText, aEl.href, ulEl);
+			if (hiddenEls[c].hasAttribute('data-is-cloneable')) {
+				cloneItemToMoreList(hiddenEls[c]);
+			} else {
+				var aText = (typeof aEl.textContent !== 'undefined') ? aEl.textContent : aEl.innerText;
+				addItemToMoreList(aText, aEl.href, ulEl);
+			}
 		}
 	}
 


### PR DESCRIPTION
Added the ability to clone a node into sub nav by adding a 'data-is-cloneable' attribute to a 'li' tag. Without this it defaults to current behaviour of copying the link text and href.