### PR TITLE
Added ability to clone nodes when generating sub-nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ If there's a chance that all nav items will be hidden and added to the More list
 <li data-more class="o-hierarchical-nav__parent"><a><span class="nav__more--if-some">More</span><span class="nav__more--if-all">Menu</span></a></li>
 ```
 
+If there is a structure required for the styling of nav components (i.e. other elements are required for icon display) or elements that are not links but should reduce to a sub-level when screen space does not allow then you can add a 'data-o-hierarchical-nav--is-cloneable' attribute and the element will be deeply cloned rather than a new anchor tag with the text content copied.
+
+```html
+<li data-o-hierarchical-nav--is-cloneable><a><div>An item to clone</div><img src="" alt="icon"></a></li>
+
 ## Vertical hierarchical nav
 
 To make a nav work in a vertical layout, add `data-o-hierarchical-nav-orientiation="vertical"` to the `<nav>`.
@@ -111,7 +116,7 @@ To make a nav work in a vertical layout, add `data-o-hierarchical-nav-orientiati
 
 Add a `<i></i>` to display an arrow icon at the end of an `<a>` element:
 
-```html 
+```html
 <li class="o-hierarchical-nav__parent"><a>Item 3.2 (parent) <i></i></a>
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ If there is a structure required for the styling of nav components (i.e. other e
 
 ```html
 <li data-o-hierarchical-nav--is-cloneable><a><div>An item to clone</div><img src="" alt="icon"></a></li>
+```
 
 ## Vertical hierarchical nav
 

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ If there's a chance that all nav items will be hidden and added to the More list
 <li data-more class="o-hierarchical-nav__parent"><a><span class="nav__more--if-some">More</span><span class="nav__more--if-all">Menu</span></a></li>
 ```
 
-If there is a structure required for the styling of nav components (i.e. other elements are required for icon display) or elements that are not links but should reduce to a sub-level when screen space does not allow then you can add a 'data-o-hierarchical-nav--is-cloneable' attribute and the element will be deeply cloned rather than a new anchor tag with the text content copied.
+If there is a structure required for the styling of nav components (i.e. other elements are required for icon display) or elements that are not links but should reduce to a sub-level when screen space does not allow then you can add a 'data-o-hierarchical-nav-is-cloneable' attribute and the element will be deeply cloned rather than a new anchor tag with the text content copied.
 
 ```html
-<li data-o-hierarchical-nav--is-cloneable><a><div>An item to clone</div><img src="" alt="icon"></a></li>
+<li data-o-hierarchical-nav-is-cloneable><a><div>An item to clone</div><img src="" alt="icon"></a></li>
 ```
 
 ## Vertical hierarchical nav

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Each _navigation item_ can be either:
 
 * __Plain text__: must still be wrapped in `<a>` tag, e.g. `<a>World</a>`
 * __Linked text__: e.g. `<a href="/world">World</a>`
+* __Sub Component__: must be wrapped in `<li>` with a `data-o-hierarchical-nav-is-cloneable` attribute, e.g `<li data-o-hierarchical-nav-is-cloneable>...</li>`
 
 …and can have one of the following behaviours:
 
@@ -102,11 +103,12 @@ If there's a chance that all nav items will be hidden and added to the More list
 ```html
 <li data-more class="o-hierarchical-nav__parent"><a><span class="nav__more--if-some">More</span><span class="nav__more--if-all">Menu</span></a></li>
 ```
+#### Sub-Components
 
 If there is a structure required for the styling of nav components (i.e. other elements are required for icon display) or elements that are not links but should reduce to a sub-level when screen space does not allow then you can add a 'data-o-hierarchical-nav-is-cloneable' attribute and the element will be deeply cloned rather than a new anchor tag with the text content copied.
 
 ```html
-<li data-o-hierarchical-nav-is-cloneable><a><div>An item to clone</div><img src="" alt="icon"></a></li>
+<li data-o-hierarchical-nav-is-cloneable><div><span>An item to clone</span><img src="" alt="icon"></div></li>
 ```
 
 ## Vertical hierarchical nav

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ If there's a chance that all nav items will be hidden and added to the More list
 If there is a structure required for the styling of nav components (i.e. other elements are required for icon display) or elements that are not links but should reduce to a sub-level when screen space does not allow then you can add a 'data-o-hierarchical-nav-is-cloneable' attribute and the element will be deeply cloned rather than a new anchor tag with the text content copied.
 
 ```html
-<li data-o-hierarchical-nav-is-cloneable><div><span>An item to clone</span><img src="" alt="icon"></div></li>
+<li data-o-hierarchical-nav-is-cloneable><a><span>An item to clone</span><img src="" alt="icon"></a></li>
 ```
 
 ## Vertical hierarchical nav

--- a/demos/src/config.json
+++ b/demos/src/config.json
@@ -18,6 +18,10 @@
             "name": "nav",
             "template": "demos/src/nav.mustache",
             "js": "demos/src/nav.js"
+        },
+        {
+            "name": "sub-component",
+            "template": "demos/src/sub-component.mustache"
         }
     ]
 }

--- a/demos/src/config.json
+++ b/demos/src/config.json
@@ -21,7 +21,8 @@
         },
         {
             "name": "sub-component",
-            "template": "demos/src/sub-component.mustache"
+            "template": "demos/src/sub-component.mustache",
+            "sass": "demos/src/scss/sub-component.scss"
         }
     ]
 }

--- a/demos/src/scss/demo.scss
+++ b/demos/src/scss/demo.scss
@@ -39,36 +39,3 @@ body {
 .demo--horizontal-theme {
 	@include oHierarchicalNavHorizontalTheme;
 }
-
-.signin__nav {
-	text-align: center;
-	li {
-		box-sizing: border-box;
-		margin: 10px;
-		width: 200px;
-		input,
-		label,
-		button {
-			border: 0;
-			border-radius: 5px;
-			box-sizing: border-box;
-			padding: 10px;
-			width: 50%;
-		}
-		label,
-		button {
-			color: #ffffff;
-		}
-		button {
-			background: #cc0000;
-		}
-	}
-	[data-o-hierarchical-nav-level] [data-o-hierarchical-nav-level] {
-		border-radius: 0 0 10px 10px;
-		margin-top: 10px;
-		text-align: right;
-		li {
-			border-top: 0;
-		}
-	}
-}

--- a/demos/src/scss/demo.scss
+++ b/demos/src/scss/demo.scss
@@ -44,26 +44,31 @@ body {
 	text-align: center;
 	li {
 		box-sizing: border-box;
-		min-width: 200px;
 		margin: 10px;
-		input, button {
-			border: none;
+		width: 200px;
+		input,
+		label,
+		button {
+			border: 0;
 			border-radius: 5px;
 			box-sizing: border-box;
-			font-size: 16px;
 			padding: 10px;
-			width: 100%;
+			width: 50%;
+		}
+		label,
+		button {
+			color: #ffffff;
 		}
 		button {
-			background: #c00;
-			color: #fff;
+			background: #cc0000;
 		}
-		[data-o-hierarchical-nav-level="2"] {
-			border-radius: 0 0 10px 10px;
-			margin-top: 10px;
-			li {
-				border: none !important;
-			}
+	}
+	[data-o-hierarchical-nav-level] [data-o-hierarchical-nav-level] {
+		border-radius: 0 0 10px 10px;
+		margin-top: 10px;
+		text-align: right;
+		li {
+			border-top: 0;
 		}
 	}
 }

--- a/demos/src/scss/demo.scss
+++ b/demos/src/scss/demo.scss
@@ -39,3 +39,31 @@ body {
 .demo--horizontal-theme {
 	@include oHierarchicalNavHorizontalTheme;
 }
+
+.signin__nav {
+	text-align: center;
+	li {
+		box-sizing: border-box;
+		min-width: 200px;
+		margin: 10px;
+		input, button {
+			border: none;
+			border-radius: 5px;
+			box-sizing: border-box;
+			font-size: 16px;
+			padding: 10px;
+			width: 100%;
+		}
+		button {
+			background: #c00;
+			color: #fff;
+		}
+		[data-o-hierarchical-nav-level="2"] {
+			border-radius: 0 0 10px 10px;
+			margin-top: 10px;
+			li {
+				border: none !important;
+			}
+		}
+	}
+}

--- a/demos/src/scss/sub-component.scss
+++ b/demos/src/scss/sub-component.scss
@@ -1,0 +1,34 @@
+@import './demo';
+
+.signin__nav {
+	text-align: center;
+	li {
+		box-sizing: border-box;
+		margin: 10px;
+		width: 200px;
+		input,
+		label,
+		button {
+			border: 0;
+			border-radius: 5px;
+			box-sizing: border-box;
+			padding: 10px;
+			width: 50%;
+		}
+		label,
+		button {
+			color: #ffffff;
+		}
+		button {
+			background: #cc0000;
+		}
+	}
+	[data-o-hierarchical-nav-level] [data-o-hierarchical-nav-level] {
+		border-radius: 0 0 10px 10px;
+		margin-top: 10px;
+		text-align: right;
+		li {
+			border-top: 0;
+		}
+	}
+}

--- a/demos/src/sub-component.mustache
+++ b/demos/src/sub-component.mustache
@@ -1,0 +1,13 @@
+<h1 class="demo__title">Component sub-level nav</h1>
+
+<nav class="ft-search__nav o-header__primary__right o-header__nav--tools-theme o-hierarchical-nav" data-o-component="o-hierarchical-nav">
+    <ul data-o-hierarchical-nav-level="1">
+        <li class="ft-search__nav__items" data-o-hierarchical-nav--is-cloneable>
+            <form method="get" action="/search/" id="site-wide-search">
+                <input class="search-query" type="search" name="SearchText" id="site-wide-search-field" placeholder="Search by keyword...">
+                <input name="SearchButton" type="submit" style="display:none;">
+            </form>
+        </li>
+        <li data-more class="o-hierarchical-nav__parent" aria-hidden="true"><a><span class="o-hierarchical-nav__more--if-some">More</span><span class="o-hierarchical-nav__more--if-all">Menu</span> <i></i></a></li>
+    </ul>
+</nav>

--- a/demos/src/sub-component.mustache
+++ b/demos/src/sub-component.mustache
@@ -1,17 +1,17 @@
 <h1 class="demo__title">Component sub-level nav</h1>
 
 <nav class="signin__nav o-hierarchical-nav demo--horizontal-theme" data-o-component="o-hierarchical-nav">
-    <form method="get" action="/search/" id="site-wide-search">
+    <form method="get" action="/search/" id="signin-form">
         <ul data-o-hierarchical-nav-level="1">
             <li data-priority="1" data-o-hierarchical-nav-is-cloneable>
                 <label for="email">Email</label>
                 <input class="signin-email" type="email" name="email" id="email" placeholder="Email" />
             </li>
-            <li data-priority="1" class="ft-search__nav__items" data-o-hierarchical-nav-is-cloneable>
+            <li data-priority="1" data-o-hierarchical-nav-is-cloneable>
                 <label for="password">Password</label>
                 <input class="signin_password" type="password" name="password" id="password" placeholder="Password" />
             </li>
-            <li data-priority="1" class="ft-search__nav__items" data-o-hierarchical-nav-is-cloneable>
+            <li data-priority="1" data-o-hierarchical-nav-is-cloneable>
                 <button name="submit" type="submit">Sign in</button>
             </li>
             <li data-more class="o-hierarchical-nav__parent" aria-hidden="true">

--- a/demos/src/sub-component.mustache
+++ b/demos/src/sub-component.mustache
@@ -3,15 +3,15 @@
 <nav class="signin__nav o-hierarchical-nav demo--horizontal-theme" data-o-component="o-hierarchical-nav">
     <form method="get" action="/search/" id="site-wide-search">
         <ul data-o-hierarchical-nav-level="1">
-            <li data-priority="1" data-o-hierarchical-nav--is-cloneable>
+            <li data-priority="1" data-o-hierarchical-nav-is-cloneable>
                 <label for="email">Email</label>
                 <input class="signin-email" type="email" name="email" id="email" placeholder="Email" />
             </li>
-            <li data-priority="1" class="ft-search__nav__items" data-o-hierarchical-nav--is-cloneable>
+            <li data-priority="1" class="ft-search__nav__items" data-o-hierarchical-nav-is-cloneable>
                 <label for="password">Password</label>
                 <input class="signin_password" type="password" name="password" id="password" placeholder="Password" />
             </li>
-            <li data-priority="1" class="ft-search__nav__items" data-o-hierarchical-nav--is-cloneable>
+            <li data-priority="1" class="ft-search__nav__items" data-o-hierarchical-nav-is-cloneable>
                 <button name="submit" type="submit">Sign in</button>
             </li>
             <li data-more class="o-hierarchical-nav__parent" aria-hidden="true">

--- a/demos/src/sub-component.mustache
+++ b/demos/src/sub-component.mustache
@@ -1,13 +1,24 @@
 <h1 class="demo__title">Component sub-level nav</h1>
 
-<nav class="ft-search__nav o-header__primary__right o-header__nav--tools-theme o-hierarchical-nav" data-o-component="o-hierarchical-nav">
-    <ul data-o-hierarchical-nav-level="1">
-        <li class="ft-search__nav__items" data-o-hierarchical-nav--is-cloneable>
-            <form method="get" action="/search/" id="site-wide-search">
-                <input class="search-query" type="search" name="SearchText" id="site-wide-search-field" placeholder="Search by keyword...">
-                <input name="SearchButton" type="submit" style="display:none;">
-            </form>
-        </li>
-        <li data-more class="o-hierarchical-nav__parent" aria-hidden="true"><a><span class="o-hierarchical-nav__more--if-some">More</span><span class="o-hierarchical-nav__more--if-all">Menu</span> <i></i></a></li>
-    </ul>
+<nav class="signin__nav o-hierarchical-nav demo--horizontal-theme" data-o-component="o-hierarchical-nav">
+    <form method="get" action="/search/" id="site-wide-search">
+        <ul data-o-hierarchical-nav-level="1">
+            <li data-priority="1" data-o-hierarchical-nav--is-cloneable>
+                <input class="signin-email" type="email" name="email" placeholder="Email">
+            </li>
+            <li data-priority="1" class="ft-search__nav__items" data-o-hierarchical-nav--is-cloneable>
+                <input class="signin_password" type="password" name="password" placeholder="Password">
+            </li>
+            <li data-priority="1" class="ft-search__nav__items" data-o-hierarchical-nav--is-cloneable>
+                <button name="submit" type="submit">Sign in</button>
+            </li>
+            <li data-more class="o-hierarchical-nav__parent" aria-hidden="true">
+                <a>
+                    <span class="o-hierarchical-nav__more--if-some">More</span>
+                    <span class="o-hierarchical-nav__more--if-all">Sign in</span>
+                    <i></i>
+                </a>
+            </li>
+        </ul>
+    </form>
 </nav>

--- a/demos/src/sub-component.mustache
+++ b/demos/src/sub-component.mustache
@@ -4,10 +4,12 @@
     <form method="get" action="/search/" id="site-wide-search">
         <ul data-o-hierarchical-nav-level="1">
             <li data-priority="1" data-o-hierarchical-nav--is-cloneable>
-                <input class="signin-email" type="email" name="email" placeholder="Email">
+                <label for="email">Email</label>
+                <input class="signin-email" type="email" name="email" id="email" placeholder="Email" />
             </li>
             <li data-priority="1" class="ft-search__nav__items" data-o-hierarchical-nav--is-cloneable>
-                <input class="signin_password" type="password" name="password" placeholder="Password">
+                <label for="password">Password</label>
+                <input class="signin_password" type="password" name="password" id="password" placeholder="Password" />
             </li>
             <li data-priority="1" class="ft-search__nav__items" data-o-hierarchical-nav--is-cloneable>
                 <button name="submit" type="submit">Sign in</button>

--- a/demos/sub-component.html
+++ b/demos/sub-component.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html class="o-hoverable-on o-hoverable-on">
+<head>
+	<meta charset="utf-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+	<title>o-hierarchical-nav: sub-component demo</title>
+	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=classlist,createevent,datauri,cssgradients,mediaqueries,csstransitions,default"></script>
+	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
+	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
+	<link rel="stylesheet" href="/bundles/css?modules=o-hierarchical-nav:/demos/src/scss/demo.scss,o-fonts@^1.4.0" />
+</head>
+<body>
+<h1 class="demo__title">Component sub-level nav</h1>
+
+<nav class="ft-search__nav o-header__primary__right o-header__nav--tools-theme o-hierarchical-nav" data-o-component="o-hierarchical-nav">
+    <ul data-o-hierarchical-nav-level="1">
+        <li class="ft-search__nav__items" data-o-hierarchical-nav--is-cloneable>
+            <form method="get" action="/search/" id="site-wide-search">
+                <input class="search-query" type="search" name="SearchText" id="site-wide-search-field" placeholder="Search by keyword...">
+                <input name="SearchButton" type="submit" style="display:none;">
+            </form>
+        </li>
+        <li data-more class="o-hierarchical-nav__parent" aria-hidden="true"><a><span class="o-hierarchical-nav__more--if-some">More</span><span class="o-hierarchical-nav__more--if-all">Menu</span> <i></i></a></li>
+    </ul>
+</nav>
+
+<script src="/bundles/js?modules=o-hierarchical-nav:/demos/src/responsive-nav.js,o-fonts@^1.4.0"></script>
+<script src="//registry.origami.ft.com/embedapi?autoload=resize"></script>
+</body>
+</html>

--- a/origami.json
+++ b/origami.json
@@ -34,6 +34,11 @@
             "path": "/demos/mega-dropdown.html",
             "expanded": false,
             "description": ""
+        },
+        {
+            "path": "/demos/sub-component.html",
+            "expanded": false,
+            "description": ""
         }
     ]
 }

--- a/src/js/ResponsiveNav.js
+++ b/src/js/ResponsiveNav.js
@@ -77,6 +77,10 @@ function ResponsiveNav(rootEl) {
 	}
 
 	function prefixIds(el) {
+		// id's are prefixed to ensure that any id based functionality uses the visible element
+		// 
+		// for example a 'label' tag with a 'for' attribute will not find the correct input it
+		// relates to as it uses the first matching id in the document
 		var child;
 		if (el.hasChildNodes()) {
 			var children = el.childNodes;

--- a/src/js/ResponsiveNav.js
+++ b/src/js/ResponsiveNav.js
@@ -1,4 +1,4 @@
-/*global require,module*/
+/*global require,module,document,HTMLElement*/
 'use strict';
 
 var SquishyList = require('o-squishy-list');
@@ -60,7 +60,7 @@ function ResponsiveNav(rootEl) {
 		// remove the attributes that are only applicable to higher level
 		cloneEl.removeAttribute('data-priority');
 		cloneEl.removeAttribute('aria-hidden');
-		cloneEl.removeAttribute('data-is-cloneable');
+		cloneEl.removeAttribute('data-o-hierarchical-nav--is-cloneable');
 		moreListEl.appendChild(cloneEl);
 	}
 
@@ -72,7 +72,7 @@ function ResponsiveNav(rootEl) {
 			var aEl = hiddenEls[c].querySelector('a');
 			var ulEl = hiddenEls[c].querySelector('ul');
 
-			if (hiddenEls[c].hasAttribute('data-is-cloneable')) {
+			if (hiddenEls[c].hasAttribute('data-o-hierarchical-nav--is-cloneable')) {
 				cloneItemToMoreList(hiddenEls[c]);
 			} else {
 				var aText = (typeof aEl.textContent !== 'undefined') ? aEl.textContent : aEl.innerText;

--- a/src/js/ResponsiveNav.js
+++ b/src/js/ResponsiveNav.js
@@ -77,7 +77,7 @@ function ResponsiveNav(rootEl) {
 	}
 
 	function prefixIds(el) {
-		var newId, child;
+		var child;
 		if (el.hasChildNodes()) {
 			var children = el.childNodes;
 			for (var i = 0, l = children.length; i < l; i++) {

--- a/src/js/ResponsiveNav.js
+++ b/src/js/ResponsiveNav.js
@@ -62,7 +62,7 @@ function ResponsiveNav(rootEl) {
 		// remove the attributes that are only applicable to higher level
 		cloneEl.removeAttribute('data-priority');
 		cloneEl.removeAttribute('aria-hidden');
-		cloneEl.removeAttribute('data-o-hierarchical-nav--is-cloneable');
+		cloneEl.removeAttribute('data-o-hierarchical-nav-is-cloneable');
 		// recurse through children and amend any id values to maintain uniqueness
 		prefixIds(el);
 		moreListEl.appendChild(cloneEl);
@@ -102,7 +102,7 @@ function ResponsiveNav(rootEl) {
 			var aEl = hiddenEls[c].querySelector('a');
 			var ulEl = hiddenEls[c].querySelector('ul');
 
-			if (hiddenEls[c].hasAttribute('data-o-hierarchical-nav--is-cloneable')) {
+			if (hiddenEls[c].hasAttribute('data-o-hierarchical-nav-is-cloneable')) {
 				cloneItemToMoreList(hiddenEls[c]);
 			} else {
 				var aText = (typeof aEl.textContent !== 'undefined') ? aEl.textContent : aEl.innerText;

--- a/src/js/ResponsiveNav.js
+++ b/src/js/ResponsiveNav.js
@@ -78,7 +78,6 @@ function ResponsiveNav(rootEl) {
 
 	function prefixIds(el) {
 		// id's are prefixed to ensure that any id based functionality uses the visible element
-		// 
 		// for example a 'label' tag with a 'for' attribute will not find the correct input it
 		// relates to as it uses the first matching id in the document
 		var child;

--- a/src/js/ResponsiveNav.js
+++ b/src/js/ResponsiveNav.js
@@ -55,6 +55,15 @@ function ResponsiveNav(rootEl) {
 		moreListEl.appendChild(itemEl);
 	}
 
+	function cloneItemToMoreList(el) {
+		var cloneEl = el.cloneNode(true);
+		// remove the attributes that are only applicable to higher level
+		cloneEl.removeAttribute('data-priority');
+		cloneEl.removeAttribute('aria-hidden');
+		cloneEl.removeAttribute('data-is-cloneable');
+		moreListEl.appendChild(cloneEl);
+	}
+
 	// For every hidden item, add it to the more list
 	function populateMoreList(hiddenEls) {
 		emptyMoreList();
@@ -63,8 +72,12 @@ function ResponsiveNav(rootEl) {
 			var aEl = hiddenEls[c].querySelector('a');
 			var ulEl = hiddenEls[c].querySelector('ul');
 
-			var aText = (typeof aEl.textContent !== 'undefined') ? aEl.textContent : aEl.innerText;
-			addItemToMoreList(aText, aEl.href, ulEl);
+			if (hiddenEls[c].hasAttribute('data-is-cloneable')) {
+				cloneItemToMoreList(hiddenEls[c]);
+			} else {
+				var aText = (typeof aEl.textContent !== 'undefined') ? aEl.textContent : aEl.innerText;
+				addItemToMoreList(aText, aEl.href, ulEl);
+			}
 		}
 	}
 


### PR DESCRIPTION
This branch allows the addition of a 'data-o-hierarchical-nav--is-cloneable' attribute that will deeply clone a node when creating a sub-nav. This adds the ability to have more complex components appearing in navigation (e.g. form elements) than is currently allowed. Any child elements that have 'id' attributes will have these prefixed with 'o-hierarchical-nav__cloned-id-' to maintain uniqueness as well as meaning, in the case of forms, that any label tags will still function correctly.