### PR TITLE
'oSquishyList.change' listener is added after the list is instantiated

### DIFF
--- a/src/js/ResponsiveNav.js
+++ b/src/js/ResponsiveNav.js
@@ -156,6 +156,8 @@ function ResponsiveNav(rootEl) {
 		contentFilterEl = rootEl.querySelector('ul');
 		moreEl = rootEl.querySelector('[data-more]');
 
+		rootDelegate.on('oSquishyList.change', contentFilterChangeHandler);
+
 		if (contentFilterEl) {
 			contentFilter = new SquishyList(contentFilterEl, { filterOnResize: false });
 		}
@@ -171,8 +173,6 @@ function ResponsiveNav(rootEl) {
 				rootDelegate.on('oLayers.new', navExpandHandler);
 			}
 		}
-
-		rootDelegate.on('oSquishyList.change', contentFilterChangeHandler);
 
 		var bodyDelegate = new DomDelegate(document.body);
 


### PR DESCRIPTION
The listener for the 'oSquishyList.change' event is added after the list is instantiated which means that it misses out on the first time it is triggered and can lead to the 'All' element not displaying.