### PR TITLE
On mobile devices the keyboard is shown and hides when clicking on a nested form input

### DIFF
--- a/demos/src/responsive-nav.js
+++ b/demos/src/responsive-nav.js
@@ -1,8 +1,7 @@
 /*global require*/
-
+'use strict';
 require('../../main.js');
 
 document.addEventListener('DOMContentLoaded', function() {
-	'use strict';
 	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
 });

--- a/src/js/ResponsiveNav.js
+++ b/src/js/ResponsiveNav.js
@@ -28,9 +28,6 @@ function ResponsiveNav(rootEl) {
 
 		if (contentFilter) {
 			contentFilter.squish();
-			if (!isMegaDropdownControl(moreEl)) {
-				populateMoreList(contentFilter.getHiddenItems());
-			}
 		}
 	}
 
@@ -131,6 +128,9 @@ function ResponsiveNav(rootEl) {
 
 	// When there's an o-squishy-list change, collapse all elements and run the setMoreElClass method with number of non-hidden elements
 	function contentFilterChangeHandler(ev) {
+        if (contentFilter && !isMegaDropdownControl(moreEl)) {
+            populateMoreList(contentFilter.getHiddenItems());
+        }
 		if (ev.target === contentFilterEl && ev.detail.hiddenItems.length > 0) {
 			nav.collapseAll();
 			setMoreElClass(ev.detail.remainingItems.length);

--- a/src/js/ResponsiveNav.js
+++ b/src/js/ResponsiveNav.js
@@ -128,9 +128,9 @@ function ResponsiveNav(rootEl) {
 
 	// When there's an o-squishy-list change, collapse all elements and run the setMoreElClass method with number of non-hidden elements
 	function contentFilterChangeHandler(ev) {
-        if (contentFilter && !isMegaDropdownControl(moreEl)) {
-            populateMoreList(contentFilter.getHiddenItems());
-        }
+		if (contentFilter && !isMegaDropdownControl(moreEl)) {
+			populateMoreList(contentFilter.getHiddenItems());
+		}
 		if (ev.target === contentFilterEl && ev.detail.hiddenItems.length > 0) {
 			nav.collapseAll();
 			setMoreElClass(ev.detail.remainingItems.length);

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,8 +1,7 @@
 /*global exports*/
-
+'use strict';
 // Helper function that converts a list of elements into an array
 function nodeListToArray(nl) {
-	'use strict';
 	return [].map.call(nl, function(element) {
 		return element;
 	});
@@ -10,7 +9,6 @@ function nodeListToArray(nl) {
 
 // Helper function to dispatch events
 function dispatchCustomEvent(el, name, data) {
-	'use strict';
 	if (document.createEvent && el.dispatchEvent) {
 		var event = document.createEvent('Event');
 		event.initEvent(name, true, true);
@@ -24,7 +22,6 @@ function dispatchCustomEvent(el, name, data) {
 }
 
 function isIE8() {
-	'use strict';
 
 	var b = document.createElement('B');
 	var docElem = document.documentElement;


### PR DESCRIPTION
The 'populateMoreList' was being called in the 'resize' handler regardless of whether the list had changed. This meant that any nested form inputs would be removed which, on mobile, also removed the on screen keyboard making entry impossible. Moving it to the 'oSquishyList.change' handler means that it will only be called when required which leads to avoiding unnecessary re-draws as well as fixing the bug. This is using v2.x but is probably applicable to the current version too.