### PR TITLE
Update o-ft-icons and switch to SVG icons

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "ignore": [],
   "dependencies": {
     "o-colors": ">=2.5.0 <4",
-    "o-ft-icons": ">=2.2.1 <4",
+    "o-ft-icons": ">=3.2.0 <5",
     "o-hoverable": ">=0.1.1 <4",
     "o-viewport": ">=1.0.0 <3",
     "o-dom": ">=0.4.0 <3",

--- a/src/scss/nav-base.scss
+++ b/src/scss/nav-base.scss
@@ -16,7 +16,7 @@
 		text-decoration: none;
 		cursor: pointer;
 		outline: none;
-		color: #ffffff;
+		color: oColorsGetPaletteColor('white');
 
 		// Prevent accidental double clicks and long taps from selecting text
 		// scss-lint:disable VendorPrefixes VendorPrefix
@@ -55,7 +55,7 @@
 .o-hierarchical-nav__parent > a {
 	// scss-lint:disable SelectorDepth
 	i {
-		@include oFtIconsGetSvg('arrow-down', #ffffff, 8, 8);
+		@include oFtIconsGetSvg('arrow-down', oColorsGetPaletteColor('white'), 8, 8);
 		padding-right: 6px;
 	}
 

--- a/src/scss/nav-base.scss
+++ b/src/scss/nav-base.scss
@@ -55,16 +55,12 @@
 .o-hierarchical-nav__parent > a {
 	// scss-lint:disable SelectorDepth
 	i {
-		@extend %o-ft-icons-icon--arrow-down;
-		@include oFtIconsBaseIconStyles();
-		font-size: 8px;
-
-		// Ensure passing from normal to expanded state
-		// doesn't change the width of the menu
-		box-sizing: border-box;
-		width: 16px;
-		text-align: right;
+		@include oFtIconsGetSvg('arrow-down', #ffffff, 8, 8);
 		padding-right: 6px;
-		line-height: 16px;
+	}
+
+	&:focus i,
+	#{$o-hoverable-if-hover-enabled} &:hover i {
+		@include oFtIconsGetSvg('arrow-down', oColorsGetColorFor(link-title-hover, text), 8, $apply-base-styles: false);
 	}
 }

--- a/src/scss/theme-horizontal.scss
+++ b/src/scss/theme-horizontal.scss
@@ -58,7 +58,7 @@
 	// Show a right arrow when sub-level nav will be displayed to the right
 	.o-hierarchical-nav__parent.o-hierarchical-nav__outside-right[aria-expanded="true"] {
 		> a i {
-			@include oFtIconsGetSvg('arrow-right', #ffffff, 8, $apply-base-styles: false);
+			@include oFtIconsGetSvg('arrow-right', oColorsGetPaletteColor('white'), 8, $apply-base-styles: false);
 		}
 
 		> a:focus i {

--- a/src/scss/theme-horizontal.scss
+++ b/src/scss/theme-horizontal.scss
@@ -58,7 +58,11 @@
 	// Show a right arrow when sub-level nav will be displayed to the right
 	.o-hierarchical-nav__parent.o-hierarchical-nav__outside-right[aria-expanded="true"] {
 		> a i {
-			@extend %o-ft-icons-icon--arrow-right;
+			@include oFtIconsGetSvg('arrow-right', #ffffff, 8, $apply-base-styles: false);
+		}
+
+		> a:focus i {
+			@include oFtIconsGetSvg('arrow-right', oColorsGetColorFor(link-title-hover, text), 8, $apply-base-styles: false);
 		}
 	}
 


### PR DESCRIPTION
Updates version of `o-ft-icons` used and switches icons over to use the SVG mixin.