### PR TITLE
Better expansion for nested menus

### DIFF
--- a/demos/src/responsive-nav-cloneable.mustache
+++ b/demos/src/responsive-nav-cloneable.mustache
@@ -20,7 +20,21 @@
                     <ul data-o-hierarchical-nav-level="3">
                         <li><a>Item 5.2.1</a></li>
                         <li><a>Item 5.2.2</a></li>
-                        <li><a>Item 5.2.3</a></li>
+                        <li class="o-hierarchical-nav__parent"><a>Parent Item 5.2.3 <i></i></a>
+		                    <ul data-o-hierarchical-nav-level="4">
+		                        <li><a>Item 5.2.3.1</a></li>
+		                        <li><a>Item 5.2.3.2</a></li>
+		                        <li class="o-hierarchical-nav__parent"><a>Parent Item 5.2.3.3 <i></i></a>
+				                    <ul data-o-hierarchical-nav-level="5">
+				                        <li><a>Item 5.2.3.3.1</a></li>
+				                        <li><a>Item 5.2.3.3.2</a></li>
+				                        <li><a>Item 5.2.3.3.3</a></li>
+				                        <li><a>Item 5.2.3.3.4</a></li>
+				                    </ul>
+								</li>
+		                        <li><a>Item 5.2.3.4</a></li>
+		                    </ul>
+						</li>
                         <li><a>Item 5.2.4</a></li>
                     </ul>
                 </li>

--- a/demos/src/responsive-nav-cloneable.mustache
+++ b/demos/src/responsive-nav-cloneable.mustache
@@ -31,10 +31,10 @@
 				                        <li><a>Item 5.2.3.3.3</a></li>
 				                        <li><a>Item 5.2.3.3.4</a></li>
 				                    </ul>
-								</li>
+		                        </li>
 		                        <li><a>Item 5.2.3.4</a></li>
 		                    </ul>
-						</li>
+                        </li>
                         <li><a>Item 5.2.4</a></li>
                     </ul>
                 </li>

--- a/src/js/Nav.js
+++ b/src/js/Nav.js
@@ -183,19 +183,31 @@ function Nav(rootEl) {
 		}
 	}
 
-	// Position a level 3 nav
-	function positionLevel3s() {
-		const openLevel2El = rootEl.querySelector('[data-o-hierarchical-nav-level="2"] > [aria-expanded="true"]');
-		const openLevel3El = rootEl.querySelector('[data-o-hierarchical-nav-level="2"] > [aria-expanded="true"] > ul');
+	// Position a level 3 nav and deeper
+	function positionExpandedLevels() {
+		// find deepest expanded menu element
+		const openMenus = rootEl.querySelectorAll('li[aria-expanded="true"] > ul[data-o-hierarchical-nav-level]');
+		
+		// find the deepest level currently open
+		let deepestLevel = -1;
+		for (let c = 0, l = openMenus.length; c < l; c++) {
+			deepestLevel = Math.max(deepestLevel, openMenus[c].getAttribute("data-o-hierarchical-nav-level"));
+		}
+		
+		// start checking space / collapsing where needed
+		for (let l = 2; l <= deepestLevel; l++) {
+			const openLevelParentEl = rootEl.querySelector('[data-o-hierarchical-nav-level="'+l+'"] > [aria-expanded="true"]');
+			const openLevelChildEl = rootEl.querySelector('[data-o-hierarchical-nav-level="'+l+'"] > [aria-expanded="true"] > ul');
 
-		if (openLevel2El && openLevel3El) {
-			positionChildListEl(openLevel2El, openLevel3El);
+			if (openLevelParentEl && openLevelChildEl) {
+				positionChildListEl(openLevelParentEl, openLevelChildEl);
+			}
 		}
 	}
 
-	// Position level 3s on resize
+	// Position level 3 and below on resize
 	function resize() {
-		positionLevel3s();
+		positionExpandedLevels();
 	}
 
 	// Set all tabIndexes of a tags to 0

--- a/src/js/ResponsiveNav.js
+++ b/src/js/ResponsiveNav.js
@@ -91,8 +91,8 @@ function ResponsiveNav(rootEl) {
 				if (child instanceof HTMLElement) {
 					if (child.hasAttribute('data-o-hierarchical-nav-level')) {
 						// increment nav-level when attribute present
-						let origNavLevel = parseInt(child.getAttribute('data-o-hierarchical-nav-level'))
-						let updatedNavLevel = (isNaN(origNavLevel) ? 0 : origNavLevel) + 1
+						let origNavLevel = parseInt(child.getAttribute('data-o-hierarchical-nav-level'));
+						let updatedNavLevel = (isNaN(origNavLevel) ? 0 : origNavLevel) + 1;
 						child.setAttribute('data-o-hierarchical-nav-level', updatedNavLevel);
 					}
 					incrementMenuDepths(child);

--- a/src/scss/theme-horizontal.scss
+++ b/src/scss/theme-horizontal.scss
@@ -61,11 +61,11 @@
 		left: 100%;
 		top: 0;
 	}
+	
 	// Styling for level X, anything above 4
 	[data-o-hierarchical-nav-level] {
 		background-color: oColorsGetPaletteColor('grey-tint4');
 	}
-
 
 	// Show a right arrow when sub-level nav will be displayed to the right
 	.o-hierarchical-nav__parent.o-hierarchical-nav__outside-right[aria-expanded="true"] {

--- a/src/scss/theme-horizontal.scss
+++ b/src/scss/theme-horizontal.scss
@@ -54,6 +54,18 @@
 		left: 100%;
 		top: 0;
 	}
+	
+	// level X, anything above 3
+	.o-hierarchical-nav__parent.o-hierarchical-nav__outside-right > [data-o-hierarchical-nav-level] {
+		position: absolute;
+		left: 100%;
+		top: 0;
+	}
+	// Styling for level X, anything above 4
+	[data-o-hierarchical-nav-level] {
+		background-color: oColorsGetPaletteColor('grey-tint4');
+	}
+
 
 	// Show a right arrow when sub-level nav will be displayed to the right
 	.o-hierarchical-nav__parent.o-hierarchical-nav__outside-right[aria-expanded="true"] {
@@ -78,6 +90,8 @@
 	[data-o-hierarchical-nav-level='3'] {
 		background-color: oColorsGetPaletteColor('grey-tint4');
 	}
+
+
 
 	// Styling for a megadropdown. They are outside of the nav element, so need @at-root
 	@at-root .o-hierarchical-nav__mega-dropdown {


### PR DESCRIPTION
The current o-hierarchical-hav and its horizontal theme did not allow arbitrary nested menus. This pull request add this support:

Demo: http://cnkpreview.s3.amazonaws.com/ft1_origami/o-hierarchical-nav/better_expansion/responsive-nav-cloneable.html