### PR TITLE
widen o-icons semver range

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,6 @@
     "ftdomdelegate": ">=1.0.0 <3",
     "o-squishy-list": ">=1.0.0 <3",
     "o-layers": ">=0.2.0 <3",
-    "o-icons": "^4.4.2"
+    "o-icons": ">=4.4.2 <6"
   }
 }


### PR DESCRIPTION
So that projects can choose to migrate o-icons to v5 or leave it,
this commit widens the accepted semver range for o-icons to anything
above 4.4.2 but less than the next major (which would be 6)