### PR TITLE
Focus bug

### DIFF
--- a/demos/src/js/nav.js
+++ b/demos/src/js/nav.js
@@ -1,6 +1,6 @@
 /*global require*/
 
-const Nav = require('../../src/js/Nav');
+const Nav = require('../../../src/js/Nav');
 const navEls = document.querySelectorAll('.o-hierarchical-nav');
 
 for (let c = 0, l = navEls.length; c < l; c++) {

--- a/demos/src/js/responsive-nav.js
+++ b/demos/src/js/responsive-nav.js
@@ -1,6 +1,6 @@
 /*global require*/
 
-require('../../main.js');
+require('../../../main.js');
 
 document.addEventListener('DOMContentLoaded', function() {
 	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));

--- a/origami.json
+++ b/origami.json
@@ -27,14 +27,13 @@
 	},
 	"demosDefaults": {
 		"sass": "demos/src/scss/demo.scss",
-		"js": "demos/src/responsive-nav.js",
+		"js": "demos/src/js/responsive-nav.js",
 		"dependencies": ["o-fonts@^3.0.0","o-normalise@^1.0.0"]
 	},
 	"demos": [
 		{
 			"name": "nav",
 			"template": "demos/src/nav.mustache",
-			"js": "demos/src/nav.js",
 			"description": "A responsive multi-level menu for site navigation"
 		},
 		{

--- a/origami.json
+++ b/origami.json
@@ -28,7 +28,7 @@
 	"demosDefaults": {
 		"sass": "demos/src/scss/demo.scss",
 		"js": "demos/src/js/responsive-nav.js",
-		"dependencies": ["o-fonts@^3.0.0","o-normalise@^1.0.0"]
+		"dependencies": "o-fonts@^3.0.0,o-normalise@^1.0.0"
 	},
 	"demos": [
 		{

--- a/src/scss/nav-base.scss
+++ b/src/scss/nav-base.scss
@@ -25,7 +25,7 @@
 		// sass-lint:enable no-vendor-prefixes
 		&:focus,
 		#{$o-hoverable-if-hover-enabled} &:hover {
-			color: oColorsGetPaletteColor('white');
+			color: oColorsGetPaletteColor('paper');
 		}
 	}
 }

--- a/src/scss/nav-base.scss
+++ b/src/scss/nav-base.scss
@@ -14,7 +14,6 @@
 	a {
 		text-decoration: none;
 		cursor: pointer;
-		outline: none;
 		color: oColorsGetPaletteColor('white');
 
 		// Prevent accidental double clicks and long taps from selecting text
@@ -23,13 +22,6 @@
 		-webkit-user-select: none;
 		-ms-user-select: none;
 		// sass-lint:enable no-vendor-prefixes
-		&:focus {
-			border: 1px solid oColorsGetPaletteColor('teal-90');
-		}
-
-		#{$o-hoverable-if-hover-enabled} &:hover {
-			color: oColorsGetPaletteColor('white');
-		}
 	}
 }
 

--- a/src/scss/nav-base.scss
+++ b/src/scss/nav-base.scss
@@ -23,9 +23,12 @@
 		-webkit-user-select: none;
 		-ms-user-select: none;
 		// sass-lint:enable no-vendor-prefixes
-		&:focus,
+		&:focus {
+			border: 1px solid oColorsGetPaletteColor('teal-90');
+		}
+
 		#{$o-hoverable-if-hover-enabled} &:hover {
-			color: oColorsGetPaletteColor('paper');
+			color: oColorsGetPaletteColor('white');
 		}
 	}
 }


### PR DESCRIPTION
I can't find an exact example where the keyboard focus doesn't interact with the page — what I did find is that the focus doesn't have any distinctive styling so we can't see it change. I've left the hover as is (white on white) because there are no design decisions about this, and have added `teal-90` as a distinguishing border for keyboard focus. As far as I understand, that was an approved colour in terms of accessibility. 

Edit: Seems like Alice had previously updated a number of components to use o-normalise, so while the 'bug' was still there, changing the dependency syntax fixes it. (along with some js shuffling to get the demo to work correctly)

Closes #79 